### PR TITLE
Bugfix/004 midi note validation

### DIFF
--- a/Stori.xcodeproj/project.pbxproj
+++ b/Stori.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 				Core/Services/UndoService.swift,
 				Core/Services/UpdateManager.swift,
 				Core/Services/UserManager.swift,
+				Core/Utilities/FileNameSanitizer.swift,
 				Core/Utilities/ScrollSyncModel.swift,
 				Core/Utilities/SynchronizedScrollView.swift,
 				Features/AIComposer/ComposerTemplateBuilder.swift,

--- a/Stori/Core/Services/ProjectManager.swift
+++ b/Stori/Core/Services/ProjectManager.swift
@@ -954,60 +954,6 @@ class ProjectManager {
         return projectURL(for: project.name)
     }
     
-    /// Sanitize a string for safe use as a filename
-    /// SECURITY: Prevents path traversal, null byte injection, control characters, and other attacks
-    private func sanitizeFileName(_ name: String) -> String {
-        var sanitized = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // SECURITY: Unicode normalization to prevent look-alike attacks and filesystem inconsistencies
-        // NFD (decomposed) is Apple's preferred form for HFS+/APFS
-        sanitized = sanitized.precomposedStringWithCanonicalMapping
-        
-        // SECURITY: Remove null bytes (path truncation attack)
-        sanitized = sanitized.replacingOccurrences(of: "\0", with: "")
-        
-        // SECURITY: Remove ALL control characters (0x00-0x1F, 0x7F) that can corrupt filenames
-        sanitized = sanitized.filter { char in
-            guard let scalar = char.unicodeScalars.first else { return false }
-            let value = scalar.value
-            // Keep printable ASCII and valid Unicode, exclude control chars (0x00-0x1F, 0x7F)
-            return value >= 0x20 && value != 0x7F
-        }
-        
-        // SECURITY: Remove path traversal sequences (before replacing invalid chars)
-        sanitized = sanitized.replacingOccurrences(of: "..", with: "")
-        sanitized = sanitized.replacingOccurrences(of: "./", with: "")
-        sanitized = sanitized.replacingOccurrences(of: ".\\", with: "")
-        
-        // Remove or replace characters that aren't safe for file names
-        let invalidChars = CharacterSet(charactersIn: ":/\\?%*|\"<>")
-        sanitized = sanitized.components(separatedBy: invalidChars).joined(separator: "_")
-        
-        // Remove leading/trailing dots and underscores (hidden files on Unix, Windows compatibility)
-        sanitized = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: "._"))
-        
-        // SECURITY: Check for reserved Windows filenames (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
-        let reservedNames = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
-                             "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4",
-                             "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]
-        if reservedNames.contains(sanitized.uppercased()) {
-            sanitized = "_\(sanitized)"  // Prefix with underscore to make safe
-        }
-        
-        // Ensure we have a valid name
-        if sanitized.isEmpty {
-            sanitized = "Untitled"
-        }
-        
-        // SECURITY: Limit filename length to prevent filesystem issues
-        // macOS allows 255 bytes, but leave room for extension (.stori = 6 chars)
-        if sanitized.count > 200 {
-            sanitized = String(sanitized.prefix(200))
-        }
-        
-        return sanitized
-    }
-    
     func projectExists(withName name: String) -> Bool {
         let url = projectURL(for: name)
         return fileManager.fileExists(atPath: url.path)

--- a/Stori/Core/Utilities/FileNameSanitizer.swift
+++ b/Stori/Core/Utilities/FileNameSanitizer.swift
@@ -1,0 +1,55 @@
+// MARK: - FileNameSanitizer
+
+import Foundation
+
+/// Sanitize a string for safe use as a filename.
+/// SECURITY: Prevents path traversal, null byte injection, control characters, and other attacks.
+/// Use for project names, export filenames, and any user-controlled filename segment.
+func sanitizeFileName(_ name: String) -> String {
+    var sanitized = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // SECURITY: Unicode normalization to prevent look-alike attacks and filesystem inconsistencies
+    // NFC (precomposed) for consistent cross-platform behavior
+    sanitized = sanitized.precomposedStringWithCanonicalMapping
+
+    // SECURITY: Remove null bytes (path truncation attack)
+    sanitized = sanitized.replacingOccurrences(of: "\0", with: "")
+
+    // SECURITY: Remove ALL control characters (0x00-0x1F, 0x7F) that can corrupt filenames
+    sanitized = sanitized.filter { char in
+        guard let scalar = char.unicodeScalars.first else { return false }
+        let value = scalar.value
+        return value >= 0x20 && value != 0x7F
+    }
+
+    // SECURITY: Remove path traversal sequences (before replacing invalid chars)
+    sanitized = sanitized.replacingOccurrences(of: "..", with: "")
+    sanitized = sanitized.replacingOccurrences(of: "./", with: "")
+    sanitized = sanitized.replacingOccurrences(of: ".\\", with: "")
+
+    // Remove or replace characters that aren't safe for file names
+    let invalidChars = CharacterSet(charactersIn: ":/\\?%*|\"<>")
+    sanitized = sanitized.components(separatedBy: invalidChars).joined(separator: "_")
+
+    // Remove leading/trailing dots and underscores (hidden files on Unix, Windows compatibility)
+    sanitized = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: "._"))
+
+    // SECURITY: Check for reserved Windows filenames (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+    let reservedNames = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
+                         "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4",
+                         "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]
+    if reservedNames.contains(sanitized.uppercased()) {
+        sanitized = "_\(sanitized)"
+    }
+
+    if sanitized.isEmpty {
+        sanitized = "Untitled"
+    }
+
+    // SECURITY: Limit filename length (macOS 255 bytes; leave room for extension/timestamp)
+    if sanitized.count > 200 {
+        sanitized = String(sanitized.prefix(200))
+    }
+
+    return sanitized
+}

--- a/StoriTests/Utilities/FileNameSanitizerTests.swift
+++ b/StoriTests/Utilities/FileNameSanitizerTests.swift
@@ -1,0 +1,136 @@
+//
+//  FileNameSanitizerTests.swift
+//  StoriTests
+//
+//  Unit tests for sanitizeFileName - security-sensitive filename sanitization
+//
+
+import XCTest
+@testable import Stori
+
+final class FileNameSanitizerTests: XCTestCase {
+
+    // MARK: - Normal / Safe Names
+
+    func testSafeNameUnchanged() {
+        XCTAssertEqual(sanitizeFileName("MyProject"), "MyProject")
+        XCTAssertEqual(sanitizeFileName("Track_01"), "Track_01")
+        XCTAssertEqual(sanitizeFileName("Export-2024"), "Export-2024")
+    }
+
+    func testUnicodeNamePreserved() {
+        XCTAssertEqual(sanitizeFileName("Café"), "Café")
+        XCTAssertEqual(sanitizeFileName("プロジェクト"), "プロジェクト")
+    }
+
+    // MARK: - Whitespace
+
+    func testLeadingTrailingWhitespaceTrimmed() {
+        XCTAssertEqual(sanitizeFileName("  Project  "), "Project")
+        XCTAssertEqual(sanitizeFileName("\t\nName\n\t"), "Name")
+    }
+
+    func testLeadingTrailingDotsAndUnderscoresTrimmed() {
+        XCTAssertEqual(sanitizeFileName("..hidden"), "hidden")
+        XCTAssertEqual(sanitizeFileName("name__"), "name")
+        XCTAssertEqual(sanitizeFileName("._.file._."), "file")
+    }
+
+    // MARK: - Security: Null Bytes
+
+    func testNullBytesRemoved() {
+        XCTAssertEqual(sanitizeFileName("Project\0Name"), "ProjectName")
+        XCTAssertEqual(sanitizeFileName("\0\0Only"), "Only")
+    }
+
+    // MARK: - Security: Control Characters
+
+    func testControlCharactersRemoved() {
+        // 0x00-0x1F and 0x7F removed; 0x20 (space) and printable ASCII kept
+        let withControl = "Proj\u{01}ect\u{7f}Name"
+        XCTAssertEqual(sanitizeFileName(withControl), "ProjectName")
+    }
+
+    func testTabAndNewlineRemoved() {
+        XCTAssertEqual(sanitizeFileName("Proj\tect\nName"), "ProjectName")
+    }
+
+    // MARK: - Security: Path Traversal
+
+    func testPathTraversalSequencesRemoved() {
+        XCTAssertEqual(sanitizeFileName("..parent"), "parent")
+        XCTAssertEqual(sanitizeFileName("dir./file"), "dirfile")
+        XCTAssertEqual(sanitizeFileName(".\\windows"), "windows")
+        XCTAssertEqual(sanitizeFileName("a..b"), "ab")
+    }
+
+    // MARK: - Invalid Filename Characters
+
+    func testInvalidCharsReplacedWithUnderscore() {
+        XCTAssertEqual(sanitizeFileName("a:b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a/b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a\\b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a?b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a*b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a|b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a\"b"), "a_b")
+        XCTAssertEqual(sanitizeFileName("a<b>c"), "a_b_c")
+        XCTAssertEqual(sanitizeFileName("a%b"), "a_b")
+    }
+
+    func testMultipleInvalidChars() {
+        // Trailing underscore is trimmed by leading/trailing ._ trim
+        XCTAssertEqual(sanitizeFileName("C:/Projects/My*File?"), "C__Projects_My_File")
+    }
+
+    // MARK: - Reserved Windows Names
+
+    func testReservedWindowsNamesPrefixedWithUnderscore() {
+        XCTAssertEqual(sanitizeFileName("CON"), "_CON")
+        XCTAssertEqual(sanitizeFileName("PRN"), "_PRN")
+        XCTAssertEqual(sanitizeFileName("AUX"), "_AUX")
+        XCTAssertEqual(sanitizeFileName("NUL"), "_NUL")
+        XCTAssertEqual(sanitizeFileName("COM1"), "_COM1")
+        XCTAssertEqual(sanitizeFileName("COM9"), "_COM9")
+        XCTAssertEqual(sanitizeFileName("LPT1"), "_LPT1")
+        XCTAssertEqual(sanitizeFileName("LPT9"), "_LPT9")
+    }
+
+    func testReservedNameCaseInsensitive() {
+        XCTAssertEqual(sanitizeFileName("con"), "_con")
+        XCTAssertEqual(sanitizeFileName("nul"), "_nul")
+    }
+
+    // MARK: - Empty Result
+
+    func testEmptyAfterSanitizationBecomesUntitled() {
+        XCTAssertEqual(sanitizeFileName(""), "Untitled")
+        XCTAssertEqual(sanitizeFileName("   "), "Untitled")
+        XCTAssertEqual(sanitizeFileName("...."), "Untitled")
+        XCTAssertEqual(sanitizeFileName("::::"), "Untitled")
+        XCTAssertEqual(sanitizeFileName("\0\0\0"), "Untitled")
+    }
+
+    // MARK: - Length Cap
+
+    func testLongNameTruncatedTo200() {
+        let long = String(repeating: "a", count: 300)
+        let result = sanitizeFileName(long)
+        XCTAssertEqual(result.count, 200)
+        XCTAssertTrue(result.allSatisfy { $0 == "a" })
+    }
+
+    func testNameAt200CharactersUnchanged() {
+        let exactly200 = String(repeating: "x", count: 200)
+        XCTAssertEqual(sanitizeFileName(exactly200), exactly200)
+    }
+
+    // MARK: - Unicode Normalization
+
+    func testUnicodeNormalizationApplied() {
+        // é as single codepoint (U+00E9) vs e + combining acute (U+0065 U+0301) both normalize to same NFC form
+        let precomposed = "Café"
+        let decomposed = "Cafe\u{0301}"
+        XCTAssertEqual(sanitizeFileName(precomposed), sanitizeFileName(decomposed))
+    }
+}


### PR DESCRIPTION
---
title: '[BUG] MIDI Note Pitch Bounds Not Validated on Creation'
labels: bug, midi, data-validation
priority: medium
---

## Bug Description

In `MIDIModels.swift`, the `MIDINote` struct initialization (lines 47-61) does not validate that the pitch value is within the valid MIDI range (0-127). While the pitch is stored as `UInt8` which technically can't exceed 127, there's no validation that it's not being set to reserved or invalid values.

Similarly, the `transpose()` method in `MIDIRegion` (lines 182-189) clamps the result but uses `UInt8.init(clamping:)` which silently truncates out-of-range values rather than handling them explicitly.

## Steps to Reproduce

1. Create a MIDI note with pitch value 128 or higher (wraps due to UInt8)
2. Or transpose notes beyond MIDI range (C-1 or above G9)
3. The values are clamped but silently, with no indication to the user
4. Could result in unexpected pitch shifts or lost transposition data

## Expected Behavior

- MIDI note creation should validate pitch is in range 0-127 (C-1 to G9)
- Transposition that would exceed bounds should either:
  - Notify the user that notes were clamped
  - Or prevent the operation with an error message
  - Or offer "octave wrap" behavior as an option

## Actual Behavior

**MIDINote init** (lines 47-61):
```swift
init(
    id: UUID = UUID(),
    pitch: UInt8,  // ← No validation
    velocity: UInt8 = 100,
    startTime: TimeInterval,
    duration: TimeInterval,
    channel: UInt8 = 0
) {
    self.id = id
    self.pitch = pitch  // ← Accepts any UInt8 value
    // ...
}
```

**MIDIRegion.transpose()** (lines 182-189):
```swift
mutating func transpose(by semitones: Int) {
    notes = notes.map { note in
        var transposed = note
        transposed.pitch = UInt8(clamping: Int(note.pitch) + semitones)  // ← Silent clamping
        return transposed
    }
}
```

Silent clamping means:
- Note at C8 (108) + 12 semitones = 120, clamped to 120 (OK)
- Note at G8 (115) + 15 semitones = 130, clamped to 127 (G9), but user expects C9
- Loss of musical interval relationships

## Location

**File**: `Stori/Core/Models/MIDIModels.swift`  
**Lines**: 47-61 (MIDINote init), 182-189 (transpose method)

## Suggested Fix

**Option 1**: Add validation with clear error messages:
```swift
init(
    id: UUID = UUID(),
    pitch: UInt8,
    velocity: UInt8 = 100,
    startTime: TimeInterval,
    duration: TimeInterval,
    channel: UInt8 = 0
) {
    self.id = id
    self.pitch = min(127, max(0, pitch))  // Explicit clamp with documentation
    self.velocity = min(127, max(1, velocity))  // 0 velocity = note off in some contexts
    self.startTime = startTime
    self.duration = duration
    self.channel = min(15, channel)  // MIDI channels are 0-15
}
```

**Option 2**: Add transpose with feedback:
```swift
mutating func transpose(by semitones: Int) -> TransposeResult {
    var clampedNotes = 0
    notes = notes.map { note in
        var transposed = note
        let newPitch = Int(note.pitch) + semitones
        if newPitch < 0 || newPitch > 127 {
            clampedNotes += 1
        }
        transposed.pitch = UInt8(clamping: newPitch)
        return transposed
    }
    return clampedNotes > 0 ? .clamped(count: clampedNotes) : .success
}
```

## Environment

- **Affects**: All versions
- **Component**: MIDI / Piano Roll
- **Impact**: Silent data loss during transposition, potential for invalid MIDI data

## Additional Context

The Piano Roll's pitch range is defined as C0 (12) to B8 (119) in `PianoRollView.swift` (lines 95-98):
```swift
let minPitch: Int = 12   // C0
let maxPitch: Int = 119  // B8
```

But `MIDINote` allows full 0-127 range. This inconsistency should be resolved.

## Tags for New Engineers

`#good-first-issue` `#midi` `#data-validation` `#piano-roll`

This bug teaches:
- MIDI protocol specifications
- Data validation patterns in Swift
- User feedback for silent failures
- Bounds checking and clamping strategies