### PR TITLE
Bugfix/008 audio region gain db

### DIFF
--- a/Stori/Core/Models/AudioModels.swift
+++ b/Stori/Core/Models/AudioModels.swift
@@ -664,7 +664,8 @@ struct AudioRegion: Identifiable, Codable, Equatable {
             AudioRegion.amplitudeToDb(gain)
         }
         set {
-            gain = AudioRegion.dbToAmplitude(newValue)
+            let amplitude = AudioRegion.dbToAmplitude(newValue)
+            gain = max(0.0, min(2.0, amplitude))
         }
     }
     
@@ -678,9 +679,9 @@ struct AudioRegion: Identifiable, Codable, Equatable {
     
     /// Convert decibels (dB) to linear amplitude
     /// - Parameter db: Gain in dB (0 dB = unity gain, +6 dB ≈ double amplitude)
-    /// - Returns: Linear amplitude (0.0 to positive values)
+    /// - Returns: Linear amplitude (0.0 to positive values). Non-finite db (e.g. -∞, NaN) returns 0.0.
     static func dbToAmplitude(_ db: Float) -> Float {
-        guard db.isFinite else { return 0.0 }  // -∞ dB = silence
+        guard db.isFinite else { return 0.0 }  // -∞ dB = silence; NaN = invalid → 0
         return pow(10.0, db / 20.0)
     }
     

--- a/StoriTests/Models/AudioModelsTests.swift
+++ b/StoriTests/Models/AudioModelsTests.swift
@@ -455,6 +455,74 @@ final class AudioModelsTests: XCTestCase {
         XCTAssertEqual(TrackOutputDestination.output(channel: 3).displayName, "Output 3")
     }
     
+    // MARK: - AudioRegion Gain (dB ↔ Amplitude)
+    
+    func testAmplitudeToDbRoundTrip() {
+        assertApproximatelyEqual(AudioRegion.amplitudeToDb(1.0), 0.0)
+        assertApproximatelyEqual(AudioRegion.amplitudeToDb(2.0), 6.02, tolerance: 0.01)
+        assertApproximatelyEqual(AudioRegion.amplitudeToDb(0.5), -6.02, tolerance: 0.01)
+    }
+    
+    func testAmplitudeToDbEdges() {
+        XCTAssertEqual(AudioRegion.amplitudeToDb(0), -Float.infinity)
+        XCTAssertEqual(AudioRegion.amplitudeToDb(-0.1), -Float.infinity)
+    }
+    
+    func testDbToAmplitudeRoundTrip() {
+        assertApproximatelyEqual(AudioRegion.dbToAmplitude(0), 1.0)
+        assertApproximatelyEqual(AudioRegion.dbToAmplitude(6.0), 2.0, tolerance: 0.01)
+        assertApproximatelyEqual(AudioRegion.dbToAmplitude(-6.0), 0.5, tolerance: 0.01)
+    }
+    
+    func testDbToAmplitudeEdges() {
+        XCTAssertEqual(AudioRegion.dbToAmplitude(-Float.infinity), 0.0)
+        XCTAssertEqual(AudioRegion.dbToAmplitude(Float.nan), 0.0)
+    }
+    
+    func testGainDbGet() {
+        let audioFile = AudioFile(
+            name: "Test",
+            url: URL(fileURLWithPath: "/tmp/test.wav"),
+            duration: 1.0,
+            sampleRate: 48000,
+            channels: 2,
+            fileSize: 1024,
+            format: .wav
+        )
+        let region = AudioRegion(audioFile: audioFile, gain: 1.0)
+        assertApproximatelyEqual(region.gainDb, 0.0)
+    }
+    
+    func testGainDbSet() {
+        let audioFile = AudioFile(
+            name: "Test",
+            url: URL(fileURLWithPath: "/tmp/test.wav"),
+            duration: 1.0,
+            sampleRate: 48000,
+            channels: 2,
+            fileSize: 1024,
+            format: .wav
+        )
+        var region = AudioRegion(audioFile: audioFile, gain: 1.0)
+        region.gainDb = 6.0
+        assertApproximatelyEqual(region.gain, 2.0, tolerance: 0.01)
+    }
+    
+    func testGainDbSetClamped() {
+        let audioFile = AudioFile(
+            name: "Test",
+            url: URL(fileURLWithPath: "/tmp/test.wav"),
+            duration: 1.0,
+            sampleRate: 48000,
+            channels: 2,
+            fileSize: 1024,
+            format: .wav
+        )
+        var region = AudioRegion(audioFile: audioFile, gain: 1.0)
+        region.gainDb = 12.0  // Would be 4.0 linear; setter clamps to 2.0
+        assertApproximatelyEqual(region.gain, 2.0, tolerance: 0.01)
+    }
+    
     // MARK: - Performance Tests
     
     func testProjectCreationPerformance() {


### PR DESCRIPTION
---
title: '[BUG] AudioRegion Clamps Gain to 0.0 Minimum, Preventing Attenuation Below Silence'
labels: bug, audio, regions, feature-gap
priority: low
---

## Bug Description

In `AudioModels.swift` (line 583), the `AudioRegion` initializer clamps gain to `max(0.0, min(2.0, gain))`. While this prevents negative gain values, it also prevents professional audio workflows where gain values below 0.0 (in dB) are needed for attenuation.

The comment says "Clamp gain to reasonable range (0.0 to 2.0, where 1.0 = unity gain)" but this is a linear amplitude scale, not dB. Professional DAWs typically use dB scale where 0 dB = unity, negative dB = attenuation, positive dB = boost.

## Steps to Reproduce

1. Create an audio region
2. Try to set gain to 0.5 (which would be -6 dB attenuation in linear scale)
3. This works
4. But there's no way to express this as dB in the API or UI
5. Gain values don't match professional audio terminology

## Expected Behavior

Professional DAW gain ranges:
- Unity gain: 0 dB (amplitude 1.0)
- Max boost: +12 dB to +20 dB (amplitude 2.0 to 4.0)
- Max attenuation: -∞ dB (amplitude 0.0)
- Typical range: -∞ to +12 dB

Either:
- **Option A**: Keep linear amplitude but document the dB equivalents
- **Option B**: Add dB conversion methods to the API
- **Option C**: Store gain in dB internally and convert to amplitude for audio processing

## Actual Behavior

```swift
init(
    audioFile: AudioFile,
    startBeat: Double = 0,
    durationBeats: Double? = nil,
    tempo: Double = 120.0,
    fadeIn: TimeInterval = 0,
    fadeOut: TimeInterval = 0,
    gain: Float = 1.0,  // ← Linear amplitude (NOT dB)
    isLooped: Bool = false,
    offset: TimeInterval = 0,
    contentLength: TimeInterval? = nil,
    clipEffects: [ClipEffect] = [],
    clipEffectsEnabled: Bool = true
) {
    // ...
    // Clamp gain to reasonable range (0.0 to 2.0, where 1.0 = unity gain)
    self.gain = max(0.0, min(2.0, gain))  // ← No dB conversion
}
```

**Issues**:
1. No dB↔amplitude conversion utilities
2. Gain range explanation doesn't mention dB equivalents
3. Max gain of 2.0 = +6 dB (reasonable, but undocumented)
4. UI/API doesn't expose dB representation

## Location

**File**: `Stori/Core/Models/AudioModels.swift`  
**Lines**: 559-589 (AudioRegion init), line 583 (gain clamping)  
**Related**: `ClipEffectType.gain` (lines 1104-1130) uses dB explicitly

## Suggested Fix

**Option 1**: Add dB conversion methods to AudioRegion:
```swift
extension AudioRegion {
    /// Convert amplitude to dB
    static func amplitudeToDb(_ amplitude: Float) -> Float {
        guard amplitude > 0 else { return -Float.infinity }
        return 20 * log10(amplitude)
    }
    
    /// Convert dB to amplitude
    static func dbToAmplitude(_ db: Float) -> Float {
        guard db > -Float.infinity else { return 0 }
        return pow(10, db / 20)
    }
    
    /// Get gain in dB
    var gainDb: Float {
        Self.amplitudeToDb(gain)
    }
    
    /// Set gain from dB value
    mutating func setGainDb(_ db: Float) {
        gain = max(0.0, min(2.0, Self.dbToAmplitude(db)))
    }
}
```

**Option 2**: Create a `Gain` value type:
```swift
struct Gain: Codable {
    private var amplitudeDec Linear: Float
    
    var amplitude: Float { linearAmplitude }
    var dB: Float {
        guard linearAmplitude > 0 else { return -Float.infinity }
        return 20 * log10(linearAmplitude)
    }
    
    init(amplitude: Float) {
        self.linearAmplitude = max(0, min(2.0, amplitude))
    }
    
    init(dB: Float) {
        let amplitude = pow(10, dB / 20)
        self.linearAmplitude = max(0, min(2.0, amplitude))
    }
}
```

**Option 3**: At minimum, add documentation:
```swift
// Clamp gain to reasonable range:
// - 0.0 = silence (-∞ dB)
// - 1.0 = unity gain (0 dB)
// - 2.0 = maximum boost (+6 dB)
// Use `ClipEffectType.gain` for per-region gain beyond this range
self.gain = max(0.0, min(2.0, gain))
```

## Environment

- **Affects**: All versions
- **Component**: Audio Models / Region Gain
- **Impact**: API/UI confusion, doesn't match professional audio workflow expectations

## Additional Context

Interestingly, `ClipEffectType.gain` (line 1105) DOES use dB explicitly:
```swift
case gain(dB: Float)
```

This inconsistency should be resolved - either both use dB, or both use amplitude with clear conversion utilities.

Related files that handle gain:
- `TrackAudioNode.swift` - applies region gain during playback
- `MixerController.swift` - handles track-level volume
- UI components that display gain controls

## Tags for New Engineers

`#good-first-issue` `#audio` `#api-design` `#music-production`

This bug teaches:
- Audio gain concepts (dB vs linear amplitude)
- Logarithmic vs linear scales
- Professional audio workflow expectations
- API consistency