### PR TITLE
Bugfix/007 playback position single source

### DIFF
--- a/StoriTests/Audio/TransportControllerTests.swift
+++ b/StoriTests/Audio/TransportControllerTests.swift
@@ -387,10 +387,8 @@ final class TransportControllerTests: XCTestCase {
         let beatsPerSecond = tempo / 60.0
         let expectedBeats = startBeat + (elapsedSeconds * beatsPerSecond)
         
-        assertApproximatelyEqual(expectedBeats, 8.0, accuracy: 0.001)
-        
         // Verify formula: beats = startBeat + (elapsedSeconds * (tempo / 60.0))
-        XCTAssertEqual(expectedBeats, 8.0, accuracy: 0.001, "4 seconds at 120 BPM should equal 8 beats")
+        assertApproximatelyEqual(expectedBeats, 8.0, tolerance: 0.001)
     }
     
     /// Test position calculation at different tempos
@@ -401,19 +399,19 @@ final class TransportControllerTests: XCTestCase {
         
         // 60 BPM: 1 beat per second → 2 seconds = 2 beats
         let beats60 = startBeat + (elapsedSeconds * (60.0 / 60.0))
-        assertApproximatelyEqual(beats60, 2.0, accuracy: 0.001)
+        assertApproximatelyEqual(beats60, 2.0, tolerance: 0.001)
         
         // 120 BPM: 2 beats per second → 2 seconds = 4 beats
         let beats120 = startBeat + (elapsedSeconds * (120.0 / 60.0))
-        assertApproximatelyEqual(beats120, 4.0, accuracy: 0.001)
+        assertApproximatelyEqual(beats120, 4.0, tolerance: 0.001)
         
         // 180 BPM: 3 beats per second → 2 seconds = 6 beats
         let beats180 = startBeat + (elapsedSeconds * (180.0 / 60.0))
-        assertApproximatelyEqual(beats180, 6.0, accuracy: 0.001)
+        assertApproximatelyEqual(beats180, 6.0, tolerance: 0.001)
         
         // 240 BPM: 4 beats per second → 2 seconds = 8 beats
         let beats240 = startBeat + (elapsedSeconds * (240.0 / 60.0))
-        assertApproximatelyEqual(beats240, 8.0, accuracy: 0.001)
+        assertApproximatelyEqual(beats240, 8.0, tolerance: 0.001)
     }
     
     /// Test that position calculation is consistent over longer durations
@@ -428,12 +426,12 @@ final class TransportControllerTests: XCTestCase {
         let expectedBeats = startBeat + (elapsedSeconds * beatsPerSecond)
         
         // At 120 BPM, 60 seconds = 120 beats
-        assertApproximatelyEqual(expectedBeats, 120.0, accuracy: 0.001)
+        assertApproximatelyEqual(expectedBeats, 120.0, tolerance: 0.001)
         
         // Test 5 minutes
         let fiveMinutes = 300.0
         let beatsIn5Min = startBeat + (fiveMinutes * beatsPerSecond)
-        assertApproximatelyEqual(beatsIn5Min, 600.0, accuracy: 0.01)
+        assertApproximatelyEqual(beatsIn5Min, 600.0, tolerance: 0.01)
     }
     
     /// Test position calculation starting from non-zero beat
@@ -447,7 +445,7 @@ final class TransportControllerTests: XCTestCase {
         let expectedBeats = startBeat + (elapsedSeconds * beatsPerSecond)
         
         // 16 + (2 * 2) = 20 beats
-        assertApproximatelyEqual(expectedBeats, 20.0, accuracy: 0.001)
+        assertApproximatelyEqual(expectedBeats, 20.0, tolerance: 0.001)
     }
     
     /// Test that the position formula is frame-accurate
@@ -465,14 +463,14 @@ final class TransportControllerTests: XCTestCase {
         let beatsPerBuffer = bufferDuration * beatsPerSecond
         
         // At 120 BPM, one 512-sample buffer at 48kHz = ~0.0213 beats
-        assertApproximatelyEqual(beatsPerBuffer, 0.0213, accuracy: 0.0001)
+        assertApproximatelyEqual(beatsPerBuffer, 0.0213, tolerance: 0.0001)
         
         // After 100 buffers (~1.07 seconds)
         let elapsed100Buffers = bufferDuration * 100
         let beats100Buffers = startBeat + (elapsed100Buffers * beatsPerSecond)
         
         // Should be ~2.13 beats
-        assertApproximatelyEqual(beats100Buffers, 2.133, accuracy: 0.001)
+        assertApproximatelyEqual(beats100Buffers, 2.133, tolerance: 0.001)
     }
     
     /// Test position consistency across rapid tempo changes
@@ -486,7 +484,7 @@ final class TransportControllerTests: XCTestCase {
         let phase1Duration = 2.0
         let phase1Tempo = 120.0
         let phase1Beats = startBeat + (phase1Duration * (phase1Tempo / 60.0))
-        assertApproximatelyEqual(phase1Beats, 4.0, accuracy: 0.001)
+        assertApproximatelyEqual(phase1Beats, 4.0, tolerance: 0.001)
         
         // Phase 2: 3 seconds at 90 BPM (starting from where phase 1 ended)
         let phase2Start = phase1Beats
@@ -495,7 +493,7 @@ final class TransportControllerTests: XCTestCase {
         let phase2Beats = phase2Start + (phase2Duration * (phase2Tempo / 60.0))
         
         // 4.0 + (3.0 * 1.5) = 4.0 + 4.5 = 8.5 beats
-        assertApproximatelyEqual(phase2Beats, 8.5, accuracy: 0.001)
+        assertApproximatelyEqual(phase2Beats, 8.5, tolerance: 0.001)
     }
     
     /// Performance test: Verify position calculation is fast enough for real-time use


### PR DESCRIPTION
# [Mission Critical] Single source of truth for playback position (no drift)

**Labels:** `audio`, `transport`, `engine`, `mission critical`, `WYHIWYG`  
**Goal:** One authoritative playback position in beats (and derived time). All consumers (transport UI, MIDI scheduler, metronome, automation, export) read from the same source so there is no drift or desync.

## Context

Playback position is used by the transport, the MIDI scheduler, the metronome, automation, and the export pipeline. If any of these uses a different clock or recomputes position from different inputs (e.g. wall time + tempo in one place, engine time in another), the result can be drift, late/early notes, or automation that doesn’t line up with audio. Mission-critical DAWs have a single, sample-accurate playhead.

## WYHIWYG impact

- **What you hear:** If the metronome, MIDI, and automation are not aligned to the same beat position, what you hear (clicks, notes, sweeps) won’t match the grid or each other.
- **Export:** Offline render must use the same notion of “current beat” and tempo so automation and events line up with playback.

## Task (engine and transport only — no UI)

1. **Identify all position consumers**  
   - List every component that needs “current playback position” or “current time in beats”: `TransportController`, `SampleAccurateMIDIScheduler`, `MetronomeEngine`, automation, `PlaybackSchedulingCoordinator`, export. For each, document where it gets position (atomic from transport, callback, recomputed from wall time, etc.).

2. **Define the single source**  
   - Choose one canonical source (e.g. `TransportController`’s atomic beat position, updated from a single place driven by the engine or a high-resolution timer). Ensure it is sample-rate and tempo aware so that “current beat” and “current time in seconds” are consistent.

3. **Route all consumers to that source**  
   - Refactor so that MIDI scheduler, metronome, automation, and any other consumer read current position only from this source (or from a thin wrapper that itself reads from it). Remove or fix any path that recomputes position independently in a way that can drift.

4. **Tests**  
   - Add a test that runs playback for a fixed duration and asserts that the reported position (from the single source) matches expected beats at the project tempo (e.g. 4 bars at 120 BPM = 8 seconds, position matches). Optional: assert that MIDI events and metronome ticks align to the same grid.

## Acceptance criteria

- [ ] One clearly defined source of truth for “current playback position in beats” (and derived time).
- [ ] All identified consumers use that source; no independent position derivation that can drift.
- [ ] At least one test validates position consistency over time; no regressions in playback or export.

## Files to start from

- `Stori/Core/Audio/TransportController.swift` — atomic position, `atomicBeatPosition`, `playbackStartWallTime`.
- `Stori/Core/Audio/SampleAccurateMIDIScheduler.swift` — MIDI timing reference.
- `Stori/Core/Audio/MetronomeEngine.swift` — click timing.
- `Stori/Core/Audio/AudioEngine.swift` — who drives position updates.
- Automation and `PlaybackSchedulingCoordinator` — where they get “current time”.