### PR TITLE
Fix #80: Engine health monitor polling CPU spikes

### DIFF
--- a/StoriTests/Audio/AudioEngineTests.swift
+++ b/StoriTests/Audio/AudioEngineTests.swift
@@ -64,6 +64,22 @@ final class AudioEngineTests: XCTestCase {
         XCTAssertTrue(engine.isGraphReadyForPlayback)
     }
     
+    // MARK: - Health Monitoring (issue #80: low priority to avoid CPU spikes)
+    
+    /// Engine health checks must run on low-priority queue (.utility) so they don't compete with audio.
+    func testHealthMonitorRunsOnLowPriorityQueue() {
+        XCTAssertEqual(
+            AudioEngine.healthMonitorQueueQoSForTesting,
+            DispatchQoS.QoSClass.utility,
+            "Health monitor queue must use .utility QoS to avoid periodic CPU spikes during playback"
+        )
+        XCTAssertEqual(
+            AudioEngine.healthMonitorQueueLabelForTesting,
+            "com.stori.engine.health",
+            "Health monitor queue label must be stable for diagnostics"
+        )
+    }
+    
     // MARK: - Start/Stop Tests
     
     func testEngineStart() async throws {


### PR DESCRIPTION
## Summary
Resolves periodic CPU spikes caused by engine health monitor polling that could coincide with audio buffer deadlines and cause intermittent glitches.

Fixes #80

## Changes

### AudioEngine.swift
- **Low-priority queue**: Health timer already ran on `.utility`; kept and documented. Timer handler now stays on that queue and only dispatches to MainActor when needed.
- **Cache to avoid MainActor every tick**: Added thread-safe `_atomicEngineExpectedToRun` and `_atomicLastKnownEngineRunning`. Timer reads these on the health queue; only when cache suggests desync or when due for a staggered refresh do we run `checkEngineHealth()` on MainActor.
- **Staggered refresh**: Refresh every 6 ticks (~12s) when transport is stopped, every 15 ticks (~30s) when playing (backoff during playback).
- **Relaxed leeway**: Timer leeway increased to 400ms so fires don’t align with buffer boundaries.
- **Cache updates**: `checkEngineHealth()` updates `_atomicLastKnownEngineRunning`; start/stop paths update both atomic mirrors.

### Tests (AudioEngineHealthMonitorTests, AudioEngineTests)
- `testHealthMonitorQuickValidateCPUBudget`: 1000× quickValidate, assert average &lt; 0.1ms.
- `testHealthMonitorValidateStateCPUBudget`: 500× validateState, assert average &lt; 1ms.
- `testHealthMonitorDoesNotBlockMainThreadLong`: 200× validateState in &lt; 200ms total.
- `testHealthMonitorRunsOnLowPriorityQueue`: Asserts health queue uses `.utility` QoS and expected label (constants exposed for testing).

## Testing
- `AudioEngineHealthMonitorTests`: 12 tests passed.
- `AudioEngineTests`: 60 tests passed (including new health queue test).